### PR TITLE
#Fix fix a bug for openjdk version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk
+FROM openjdk:8u181-jdk
 
 RUN apt-get update && \
     apt-get install -y gcc g++


### PR DESCRIPTION
if not set the openjdk version explicitly, the openjdk version will be latest and now is jdk 11, this will destroy the demo